### PR TITLE
Use nrows when loading data

### DIFF
--- a/TaxiFareModel/data.py
+++ b/TaxiFareModel/data.py
@@ -1,16 +1,22 @@
 import pandas as pd
 
 FILE_PATH = "raw_data/train.csv"
-TEST_FILE_PATH ="raw_data/test.csv"
+TEST_FILE_PATH = "raw_data/test.csv"
 
 def get_data(nrows=10_000, test=False):
-    '''returns a DataFrame with nrows from s3 bucket'''
-    if test:
-        df = pd.read_csv(TEST_FILE_PATH)
-    else:
-        # df = pd.read_csv(FILE_PATH, nrows=nrows)
-        df = pd.read_csv(FILE_PATH)
-    return df
+    """Return a DataFrame with ``nrows`` rows.
+
+    Parameters
+    ----------
+    nrows : int, default=10_000
+        Number of rows of file to read. This value is passed to
+        :func:`pandas.read_csv`.
+    test : bool, default=False
+        Whether to load the test dataset instead of the training dataset.
+    """
+
+    file_path = TEST_FILE_PATH if test else FILE_PATH
+    return pd.read_csv(file_path, nrows=nrows)
 
 
 def clean_data(df, test=False):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from TaxiFareModel import data as data_module
+
+
+def test_get_data_respects_nrows(tmp_path, monkeypatch):
+    file_path = tmp_path / 'train.csv'
+    df = pd.DataFrame({'a': range(10)})
+    df.to_csv(file_path, index=False)
+    monkeypatch.setattr(data_module, 'FILE_PATH', file_path)
+    loaded = data_module.get_data(nrows=5)
+    assert len(loaded) == 5
+
+
+def test_get_data_respects_nrows_on_test_file(tmp_path, monkeypatch):
+    file_path = tmp_path / 'test.csv'
+    df = pd.DataFrame({'a': range(20)})
+    df.to_csv(file_path, index=False)
+    monkeypatch.setattr(data_module, 'TEST_FILE_PATH', file_path)
+    loaded = data_module.get_data(nrows=7, test=True)
+    assert len(loaded) == 7


### PR DESCRIPTION
## Summary
- ensure `get_data` uses the `nrows` argument
- add tests covering `get_data`

## Testing
- `pytest` *(fails: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_688db16b6d8c83289df25afe2619d873